### PR TITLE
Fix single second text string

### DIFF
--- a/src/jquery.jcountdown.js
+++ b/src/jquery.jcountdown.js
@@ -341,7 +341,7 @@ $.fn.countdown = function( method /*, options*/ ) {
 			
 			
 			addTime( secLeft );			
-			addText( settings.secText );
+			addText( (secLeft == 1 && settings.secSingularText) ? settings.secSingularText  : settings.secText );
 						
 			if( settings.isRTL === true ) {
 				timeTasks.reverse();


### PR DESCRIPTION
The seconds text would always display as "seconds" instead of "second" even when there was only 1 second.